### PR TITLE
removed deploy and notification tags from travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,3 @@ node_js:
 - '0.10'
 - '0.12'
 script: ./run_tests.sh
-notifications:
-  email: false
-  irc:
-  - irc.freenode.org#statsd
-deploy:
-  provider: npm
-  email: d@unwiredcouch.com
-  api_key:
-    secure: IE9nz50eZsRL1Dbcxj2eY0apO1Io2swGF3ezZCzny20WgqQXiiVs24rHUi1GywDELGDc7+Vp0zJfmXigE+zTMvx0N3fTASiuDzd3C7fULa4JUSH2DoHNOXx7WSkr4EmujDsB7y1mEBDHOdBlLWBRApExt67TlYzvZiT8/Sffq3k=
-  on:
-    tags: true
-    repo: etsy/statsd


### PR DESCRIPTION
Fixed .travis.yaml to remove the deploy and notification tags
