### PR TITLE
fixed run_tests script - updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "statsd",
   "description": "A simple, lightweight network daemon to collect metrics over UDP",
   "author": "Etsy",
-  "license" : "MIT",
+  "license": "MIT",
   "scripts": {
     "test": "./run_tests.sh",
     "start": "node stats.js config.js",
@@ -11,23 +11,23 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/etsy/statsd.git"
+    "url": "https://github.com/Yelp/statsd.git"
   },
   "version": "0.7.2",
   "dependencies": {
   },
   "devDependencies": {
-    "nodeunit": "0.7.x",
-    "underscore": "1.4.x",
-    "temp": "0.4.x"
+    "nodeunit": "0.9.x",
+    "temp": "0.8.x",
+    "underscore": "1.8.x"
   },
   "optionalDependencies": {
-    "node-syslog":"schamane/node-syslog#30d44555",
-    "hashring":"3.1.0",
+    "node-syslog": "schamane/node-syslog#30d44555",
+    "hashring": "3.1.0",
     "winser": "=0.1.6"
   },
   "engines": {
-    "node" : ">=0.8"
+    "node": ">=0.8"
   },
   "bin": { "statsd": "./bin/statsd" }
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ try {
 catch(e) {
     console.log("Cannot find nodeunit module.");
     console.log("Make sure to run 'npm install nodeunit'");
-    process.exit();
+    process.exit(1);
 }
 
 process.chdir(__dirname);


### PR DESCRIPTION
-  The run_tests script now returns 1 in case the nodeunit dependency is not found.
-  Updated dependecies to their latest versions to fix the installation errors with nodejs 0.12
