### PR TITLE
remove forbidden character from metric name

### DIFF
--- a/backends/multidimensional_graphite.js
+++ b/backends/multidimensional_graphite.js
@@ -64,7 +64,7 @@ MultiDimensionalGraphite.prototype.transformKey = function(name) {
         '", \nmissing value at key: "' + part + '"');
       return;
     } else {
-      finalKeys.push([part, val].join('='));
+      finalKeys.push([part, val].join('.'));
     }
   });
 

--- a/test/multi_graphite_tests.js
+++ b/test/multi_graphite_tests.js
@@ -80,7 +80,7 @@ module.exports.testKeyTransformation = function(test) {
     ["port", "someport"] \
     ]';
   actual = proto.transformKey(testVal);
-  test.equal(actual, 'host=somehost.port=someport');
+  test.equal(actual, 'host.somehost.port.someport');
 
   test.done();
 };
@@ -142,19 +142,19 @@ module.exports.testTransformation = function(test) {
   var expected= {
     counters: {
       'statsd.bad_lines_seen': 1,
-      'host=myhost.port=23.package=somepackage': 200
+      'host.myhost.port.23.package.somepackage': 200
     },
     timers: {
-      'host=timerhost.port=342.package=timerpackage': [2, 3, 4]
+      'host.timerhost.port.342.package.timerpackage': [2, 3, 4]
     },
     gauges: {
-      'host=gaugehost.port=546.package=gaugepackage': 222
+      'host.gaugehost.port.546.package.gaugepackage': 222
     },
     sets: {
-      'host=sethost.port=546.package=setpackage': 222
+      'host.sethost.port.546.package.setpackage': 222
     },
     timer_data: {
-      'host=timerhost.port=342.package=timerpackage': {
+      'host.timerhost.port.342.package.timerpackage': {
         count_90: 1,
         mean_90: 2,
         upper_90: 3,
@@ -163,7 +163,7 @@ module.exports.testTransformation = function(test) {
     },
     counter_rates: {
       'statsd.bad_lines_seen': 1,
-      'host=myhost.port=23.package=somepackage': 0.1
+      'host.myhost.port.23.package.somepackage': 0.1
     },
     pctThreshold: [90]
   };


### PR DESCRIPTION
The graphite.js backend removes all the '=' from the metric name, so we cannot use it to separate key / value.
