### PR TITLE
Fix replica and ECONNRESET issue

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -152,12 +152,12 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
 
           break;
         case  "quit":
-          stream.end();
           break;
         default:
           stream.write("ERROR\n");
           break;
       }
+      stream.end();
     });
   });
 

--- a/proxy.js
+++ b/proxy.js
@@ -54,8 +54,8 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
   var ring = new hashring(
     node_ring, 'md5', {
       'max cache size': config.cacheSize || 10000,
-      //We don't want duplicate keys sent so replicas set to 0
-      'replicas': 0
+      //We don't want duplicate keys sent so replicas set to 1
+      'replicas': 1
     });
 
   // Do an initial rount of health checks prior to starting up the server

--- a/stats.js
+++ b/stats.js
@@ -327,6 +327,7 @@ config.configFile(process.argv[2], function (config) {
               }
             }
             stream.write("health: " + healthStatus + "\n");
+            stream.end();
             break;
 
           case "stats":


### PR DESCRIPTION
Changed replica count to 1
Fixes: https://github.com/etsy/statsd/issues/468

Closing the streams after sending the health status. Before when executing `echo "health" | nc localhost 8126` the connection was never closed and netcat stopped there unless you specified a timeout.
